### PR TITLE
fix: aws region data source for tf12 (and ordered_placement_strategy)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -40,7 +40,7 @@ resource "aws_ecs_service" "pganalyze" {
   task_definition = aws_ecs_task_definition.pganalyze[0].arn
   desired_count   = 1
 
-  placement_strategy {
+  ordered_placement_strategy {
     type  = "binpack"
     field = "memory"
   }

--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,6 @@ data "aws_ecs_cluster" "ecs" {
 }
 
 data "aws_region" "current" {
-  current = true
 }
 
 data "template_file" "pganalyze" {


### PR DESCRIPTION
- region data source defaults to current provider region if no other filtering is enabled,
and this is now an error in tf12 validate

- also fix ecs_service placement_strategy to ordered_placement_strategy for tf12 validate